### PR TITLE
Update bide to fix isDefAndNotNull removal

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-ui-router "1.0.7-SNAPSHOT"
+(defproject district0x/district-ui-router "1.0.8-SNAPSHOT"
   :description "district UI module for URI routing"
   :url "https://github.com/district0x/district-ui-router"
   :license {:name "Eclipse Public License"
@@ -10,9 +10,9 @@
                  [re-frame "0.12.0"]
 
                  [funcool/cuerdas "2.2.0"]
-                 [district0x/bide "1.6.1"]
+                 [funcool/bide "1.7.0"]
                  [day8.re-frame/async-flow-fx "0.1.0"]
-                 
+
                  [district0x/re-frame-window-fx "1.0.2"]]
 
   :doo {:paths {:karma "./node_modules/karma/bin/karma"}


### PR DESCRIPTION
- Bide routing library used `goog.isDefAndNotNull` until version 1.6
- https://github.com/funcool/bide/blob/02030a4260d3a9978eb683b758a430169ef38e74/src/bide/impl/router.js#L61
- https://github.com/funcool/bide/blob/02030a4260d3a9978eb683b758a430169ef38e74/src/bide/impl/helpers.js#L22
- Google Closure library removed it, bide updated in 1.7

```
❯ make test-headless                        
Makefile:65: "WARNING: Optional Executable 'circleci' not on your PATH"
Makefile:74: WARNING: Wrong Node Version: 14.18.0
Makefile:75: -        Expected Version:   10.16.3
Note: You can use nvm to set your node version with 'nvm use' while in this repository.
lein doo chrome-headless once
OpenJDK 64-Bit Server VM warning: Options -Xverify:none and -noverify were deprecated in JDK 13 and will likely be removed in a future release.

;; ======================================================================
;; Testing with Chrome-headless:

20 02 2022 16:07:46.534:WARN [web-server]: 404: /tests-output/goog/deps.js
20 02 2022 16:07:46.535:WARN [web-server]: 404: /tests-output/cljs_deps.js
20 02 2022 16:07:46.538:WARN [web-server]: 404: /tests-output/cljs_deps.js
LOG: 'Testing tests.all'
ERROR: 're-frame: no handler registered for effect:', {ns: 'district.ui.router.events', name: 'active-page-changed', fqn: 'district.ui.router.events/active-page-changed', _hash: 1896224719, cljs$lang$protocol_mask$partition0$: 2153775105, cljs$lang$protocol_mask$partition1$: 4096}, '. Ignoring.'
ERROR: 're-frame: no handler registered for effect:', {ns: 'district.ui.router.events', name: 'active-page-changed', fqn: 'district.ui.router.events/active-page-changed', _hash: 1896224719, cljs$lang$protocol_mask$partition0$: 2153775105, cljs$lang$protocol_mask$partition1$: 4096}, '. Ignoring.'
ERROR: 're-frame: no handler registered for effect:', {ns: 'district.ui.router.events', name: 'active-page-changed', fqn: 'district.ui.router.events/active-page-changed', _hash: 1896224719, cljs$lang$protocol_mask$partition0$: 2153775105, cljs$lang$protocol_mask$partition1$: 4096}, '. Ignoring.'
ERROR: 're-frame: no handler registered for effect:', {ns: 'district.ui.router.events', name: 'active-page-changed', fqn: 'district.ui.router.events/active-page-changed', _hash: 1896224719, cljs$lang$protocol_mask$partition0$: 2153775105, cljs$lang$protocol_mask$partition1$: 4096}, '. Ignoring.'
ERROR: 're-frame: no handler registered for effect:', {ns: 'district.ui.router.events', name: 'active-page-changed', fqn: 'district.ui.router.events/active-page-changed', _hash: 1896224719, cljs$lang$protocol_mask$partition0$: 2153775105, cljs$lang$protocol_mask$partition1$: 4096}, '. Ignoring.'
ERROR: 're-frame: no', ':event', 'handler registered for:', {ns: 'route', name: 'b', fqn: 'route/b', _hash: 1339171229, cljs$lang$protocol_mask$partition0$: 2153775105, cljs$lang$protocol_mask$partition1$: 4096}
ERROR: 're-frame: no handler registered for effect:', {ns: 'district.ui.router.events', name: 'active-page-changed', fqn: 'district.ui.router.events/active-page-changed', _hash: 1896224719, cljs$lang$protocol_mask$partition0$: 2153775105, cljs$lang$protocol_mask$partition1$: 4096}, '. Ignoring.'
ERROR: 're-frame: no handler registered for effect:', {ns: 'district.ui.router.events', name: 'active-page-changed', fqn: 'district.ui.router.events/active-page-changed', _hash: 1896224719, cljs$lang$protocol_mask$partition0$: 2153775105, cljs$lang$protocol_mask$partition1$: 4096}, '. Ignoring.'
ERROR: 're-frame: no handler registered for effect:', {ns: 'district.ui.router.events', name: 'active-page-changed', fqn: 'district.ui.router.events/active-page-changed', _hash: 1896224719, cljs$lang$protocol_mask$partition0$: 2153775105, cljs$lang$protocol_mask$partition1$: 4096}, '. Ignoring.'
HeadlessChrome 98.0.4758 (Linux 0.0.0): Executed 4 of 4 SUCCESS (0.043 secs / 0.034 secs)
TOTAL: 4 SUCCESS

```