### PR TITLE
Fix effect invocation to avoid warn msg

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-ui-router "1.0.8-SNAPSHOT"
+(defproject district0x/district-ui-router "1.0.9-SNAPSHOT"
   :description "district UI module for URI routing"
   :url "https://github.com/district0x/district-ui-router"
   :license {:name "Eclipse Public License"

--- a/src/district/ui/router/events.cljs
+++ b/src/district/ui/router/events.cljs
@@ -65,8 +65,7 @@
   ::navigate
   interceptors
   (fn [{:keys [:db]} [name params query]]
-    (cond-> {::effects/navigate [(queries/bide-router db) name params query]
-             ::active-page-changed [name params query]}
+    (cond-> {::effects/navigate [(queries/bide-router db) name params query]}
       (queries/scroll-top? db) (assoc :window/scroll-to [0 0]))))
 
 


### PR DESCRIPTION
When navigating to a page, the effect ::active-page-changed was called. However, this effect is not defined, which caused warning in the browser.

In fact, ::active-page-changed is a event handler (not an effect), but this is already invoked when navigating to a page.

This PR removes the reference to the missing effect.